### PR TITLE
fix(Main): bind global shortcut

### DIFF
--- a/OpenInTerminal/AppDelegate.swift
+++ b/OpenInTerminal/AppDelegate.swift
@@ -8,6 +8,7 @@
 
 import Cocoa
 import OpenInTerminalCore
+import MASShortcut
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -32,6 +33,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         setStatusItemIcon()
         setStatusItemVisible()
         setStatusToggle()
+        
+        // bind global shortcuts
+        bindShortcuts()
     }
     
     func applicationWillTerminate(_ notification: Notification) {
@@ -169,6 +173,26 @@ extension AppDelegate {
             
         } catch {
             logw(error.localizedDescription)
+        }
+    }
+}
+
+extension AppDelegate {
+    // global shortcuts
+    func bindShortcuts() {
+        MASShortcutBinder.shared()?.bindShortcut(withDefaultsKey: Constants.Key.defaultTerminalShortcut) {
+            let appDelegate = NSApplication.shared.delegate as! AppDelegate
+            appDelegate.openDefaultTerminal()
+        }
+        
+        MASShortcutBinder.shared()?.bindShortcut(withDefaultsKey: Constants.Key.defaultEditorShortcut) {
+            let appDelegate = NSApplication.shared.delegate as! AppDelegate
+            appDelegate.openDefaultEditor()
+        }
+        
+        MASShortcutBinder.shared()?.bindShortcut(withDefaultsKey: Constants.Key.copyPathShortcut) {
+            let appDelegate = NSApplication.shared.delegate as! AppDelegate
+            appDelegate.copyPathToClipboard()
         }
     }
 }

--- a/OpenInTerminal/PreferencesWindow/AdvancedPreferencesViewController.swift
+++ b/OpenInTerminal/PreferencesWindow/AdvancedPreferencesViewController.swift
@@ -12,7 +12,7 @@ import ServiceManagement
 import MASShortcut
 
 class AdvancedPreferencesViewController: PreferencesViewController {
-
+    
     @IBOutlet weak var defaultTerminalShortcut: MASShortcutView!
     @IBOutlet weak var defaultEditorShortcut: MASShortcutView!
     @IBOutlet weak var copyPathShortcut: MASShortcutView!
@@ -26,26 +26,8 @@ class AdvancedPreferencesViewController: PreferencesViewController {
         defaultTerminalShortcut.associatedUserDefaultsKey = Constants.Key.defaultTerminalShortcut
         defaultEditorShortcut.associatedUserDefaultsKey = Constants.Key.defaultEditorShortcut
         copyPathShortcut.associatedUserDefaultsKey = Constants.Key.copyPathShortcut
-        
-        bindShortcuts()
     }
     
-    func bindShortcuts() {
-        MASShortcutBinder.shared()?.bindShortcut(withDefaultsKey: Constants.Key.defaultTerminalShortcut) {
-            let appDelegate = NSApplication.shared.delegate as! AppDelegate
-            appDelegate.openDefaultTerminal()
-        }
-        
-        MASShortcutBinder.shared()?.bindShortcut(withDefaultsKey: Constants.Key.defaultEditorShortcut) {
-            let appDelegate = NSApplication.shared.delegate as! AppDelegate
-            appDelegate.openDefaultEditor()
-        }
-        
-        MASShortcutBinder.shared()?.bindShortcut(withDefaultsKey: Constants.Key.copyPathShortcut) {
-            let appDelegate = NSApplication.shared.delegate as! AppDelegate
-            appDelegate.copyPathToClipboard()
-        }
-    }
     
     // MARK: Button Actions
     


### PR DESCRIPTION
## Summary of this pull request
现在的全局快捷键绑定代码在偏好设置中，所以导致激活全局快捷键需要打开偏好设置才能激活。
将绑定全局快捷键代码移到主程序中来解决此问题
## Steps to test this feature
在绑定快捷键后，退出程序重新打开。快捷键失效
