### PR TITLE
Fix a zh-Hans translation error for OpenInTerminal

### DIFF
--- a/OpenInTerminal/PreferencesWindow/zh-Hans.lproj/Preferences.strings
+++ b/OpenInTerminal/PreferencesWindow/zh-Hans.lproj/Preferences.strings
@@ -141,7 +141,7 @@
 "2we-f7-s2N.title" = "应用到访达工具栏菜单";
 
 /* Class = "NSButtonCell"; title = "Apply to Finder Context Menu"; ObjectID = "RhP-R5-Wwt"; */
-"RhP-R5-Wwt.title" = "应用到访达工具栏菜单";
+"RhP-R5-Wwt.title" = "应用到访达上下文菜单";
 
 /* Class = "NSTextFieldCell"; title = "Custom Menu Options"; ObjectID = "nWc-SM-Kes"; */
 "nWc-SM-Kes.title" = "自定义菜单选项";


### PR DESCRIPTION
## Summary of this pull request

Fix a zh-Hans translation error for OpenInTerminal preference dialog

「应用到访达工具栏菜单」-> 「应用到访达上下文菜单」

## Does this solve an existing issue? If so, add a link to it

## Steps to test this feature

- Open OpenInTerminal terminal dialog
- Go to 「工具栏」 tab
- See two selection boxes at bottom of the dialog, they should not be the same

## Screenshots

Error like this:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/2217102/79940317-615c7500-842f-11ea-9517-15bbe7bd7c99.png">

## Additional info
