### PR TITLE
feat: add support for kitty terminal

### DIFF
--- a/OpenInTerminal/Constants.swift
+++ b/OpenInTerminal/Constants.swift
@@ -27,7 +27,7 @@ struct Constants {
     }
     
     /// .terminal, .iTerm, .hyper, .alacritty
-    static let allTerminals: [TerminalType] = [.terminal, .iTerm, .hyper, .alacritty]
+    static let allTerminals: [TerminalType] = [.terminal, .iTerm, .hyper, .alacritty, .kitty]
     /// .vscode, .atom, .sublime, .vscodium, .bbedit, .vscodeInsiders, .textMate, .cotEditor, .macVim, .phpStorm
     static let allEditors: [EditorType] = [.textEdit, .vscode, .atom, .sublime, .vscodium, .bbedit, .vscodeInsiders, .textMate, .cotEditor, .macVim, .appCode, .cLion, .goLand, .intelliJIDEA, .phpStorm, .pyCharm, .rubyMine, .webStorm]
 }

--- a/OpenInTerminal/OpenInTerminal.entitlements
+++ b/OpenInTerminal/OpenInTerminal.entitlements
@@ -22,6 +22,7 @@
 		<string>com.barebones.bbedit</string>
 		<string>com.microsoft.VSCodeInsiders</string>
 		<string>com.macromates.TextMate</string>
+		<string>net.kovidgoyal.kitty</string>
 	</array>
 </dict>
 </plist>

--- a/OpenInTerminalCore/DefaultsManager.swift
+++ b/OpenInTerminalCore/DefaultsManager.swift
@@ -149,7 +149,7 @@ public class DefaultsManager {
             option = currentDefaults[.terminalNewOption]
         case .iTerm:
             option = currentDefaults[.iTermNewOption]
-        case .hyper, .alacritty:
+        case .hyper, .alacritty, .kitty:
             return nil
         }
         
@@ -177,7 +177,7 @@ public class DefaultsManager {
             if error != nil {
                 throw OITError.cannotSetItermNewOption
             }
-        case .hyper, .alacritty:
+        case .hyper, .alacritty, .kitty:
             return
         }
     }

--- a/OpenInTerminalCore/Terminals/TerminalApps/KittyApp.swift
+++ b/OpenInTerminalCore/Terminals/TerminalApps/KittyApp.swift
@@ -1,0 +1,34 @@
+//
+//  KittyApp.swift
+//  OpenInTerminalCore
+//
+//  Created by gucheng on 2020/9/8.
+//  Copyright © 2020 Jianing Wang. All rights reserved.
+//
+
+import Foundation
+
+final class KittyApp: Terminal {
+    
+    func open(_ path: String, _ newOption: NewOptionType) throws {
+        
+        guard let url = URL(string: path) else {
+            throw OITError.wrongUrl
+        }
+        
+        let source = """
+        do shell script "open -na kitty --args -1 --directory \(url.path.specialCharEscaped)"
+        """
+        
+        let script = NSAppleScript(source: source)!
+        
+        var error: NSDictionary?
+        
+        script.executeAndReturnError(&error)
+        
+        if error != nil {
+            throw OITError.cannotAccessApp(TerminalType.kitty.rawValue)
+        }
+    }
+    
+}

--- a/OpenInTerminalCore/Terminals/TerminalManager.swift
+++ b/OpenInTerminalCore/Terminals/TerminalManager.swift
@@ -45,6 +45,7 @@ public class TerminalManager {
         alert.addButton(withTitle: cancelString).refusesFirstResponder = true
         alert.addButton(withTitle: TerminalType.hyper.rawValue).refusesFirstResponder = true
         alert.addButton(withTitle: TerminalType.iTerm.rawValue).refusesFirstResponder = true
+        alert.addButton(withTitle: TerminalType.kitty.rawValue).refusesFirstResponder = true
         alert.addButton(withTitle: TerminalType.terminal.rawValue).refusesFirstResponder = true
         
         let modalResult = alert.runModal()

--- a/OpenInTerminalCore/Terminals/TerminalType.swift
+++ b/OpenInTerminalCore/Terminals/TerminalType.swift
@@ -14,6 +14,7 @@ public enum TerminalType: String {
     case iTerm = "iTerm"
     case hyper = "Hyper"
     case alacritty = "Alacritty"
+    case kitty = "Kitty"
     
     public var bundleId: String {
         switch self {
@@ -25,6 +26,8 @@ public enum TerminalType: String {
             return "co.zeit.hyper"
         case .alacritty:
             return "io.alacritty"
+        case .kitty:
+            return "net.kovidgoyal.kitty"
         }
     }
     
@@ -42,6 +45,8 @@ public enum TerminalType: String {
             return HyperApp()
         case .alacritty:
             return AlacrittyApp()
+        case .kitty:
+            return KittyApp()
         }
     }
     
@@ -59,6 +64,8 @@ public extension TerminalType {
             self = .hyper
         case "Alacritty":
             self = .alacritty
+        case "Kitty":
+            self = .kitty
         default:
             return nil
         }
@@ -74,6 +81,10 @@ extension TerminalType: Scriptable {
         case .alacritty:
             openScript = """
             do shell script "open -na Alacritty --args --working-directory " & quoted form of thePath
+            """
+        case .kitty:
+            openScript = """
+            do shell script "open -na kitty --args --directory " & quoted from thePath
             """
         default:
             let escapedName = self.rawValue.nameSpaceEscaped

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ English | [OpenInTerminal 中文说明](./Resources/README-zh.md)
 
 | Features | OpenInTerminal | OpenInTerminal-Lite & OpenInEditor-Lite |
 | --- | --- | --- |
-| Support Terminal, [iTerm](https://www.iterm2.com/), [Hyper](https://github.com/zeit/hyper) and [Alacritty](https://github.com/jwilm/alacritty). | ✅ | ✅ |
+| Support Terminal, [iTerm](https://www.iterm2.com/), [Hyper](https://github.com/zeit/hyper), [Alacritty](https://github.com/jwilm/alacritty) and [Kitty](https://sw.kovidgoyal.net/kitty/). | ✅ | ✅ |
 | Support TextEdit, [Visual Studio Code](https://code.visualstudio.com/), [VSCode Insiders](https://code.visualstudio.com/insiders/), [Atom](https://atom.io/), [Sublime Text](https://www.sublimetext.com/), [VSCodium](https://github.com/VSCodium/vscodium), [BBEdit](https://www.barebones.com/products/bbedit/), [TextMate](https://macromates.com), [CotEditor](https://coteditor.com/), [MacVim](https://github.com/macvim-dev/macvim) and [JetBrains](https://www.jetbrains.com/)(AppCode, CLion, GoLand, IntelliJ IDEA, PhpStorm, PyCharm, RubyMine, WebStorm). | ✅ | ✅ |
 | Set to open a new tab or window. | ✅ | ✅ |
 | Support English, Chinese, French, Russian, Italian and Spanish. | ✅ | ✅ |

--- a/Resources/README-Lite-zh.md
+++ b/Resources/README-Lite-zh.md
@@ -82,6 +82,7 @@ defaults remove wang.jianing.app.OpenInEditor-Lite OIT_EditorBundleIdentifier
 | 应用 | 命令 |
 | --- | --- |
 | Alacritty | `defaults write wang.jianing.app.OpenInTerminal-Lite OIT_TerminalBundleIdentifier Alacritty` |
+| Kitty | `defaults write wang.jianing.app.OpenInTerminal-Lite OIT_TerminalBundleIdentifier Kitty` |
 | TextEdit | `defaults write wang.jianing.app.OpenInEditor-Lite OIT_EditorBundleIdentifier TextEdit` |
 | VSCodium | `defaults write wang.jianing.app.OpenInEditor-Lite OIT_EditorBundleIdentifier VSCodium` |
 | BBEdit | `defaults write wang.jianing.app.OpenInEditor-Lite OIT_EditorBundleIdentifier BBEdit` |
@@ -134,6 +135,8 @@ defaults write com.googlecode.iterm2 OpenFileInNewWindows -bool true
 对于 `Hyper` 用户来说，更推荐打开新的标签页。
 
 对于 `Alacritty` 用户来说，目前只支持打开新的窗口。
+
+对于 `Kitty` 用户来说，目前只支持打开新的窗口。
 
 ## 常见问题 ❓
 

--- a/Resources/README-Lite.md
+++ b/Resources/README-Lite.md
@@ -133,6 +133,8 @@ For `Hyper` users, it is more recommended to open a new tab.
 
 For `Alacritty` users, it is only supported to open a new window now.
 
+For `Kitty` users, it is only supported to open a new window now.
+
 ## FAQ ❓
 
 <details><summary>1. I accidentally clicked on the <code>Don't Allow</code>  button.</summary><br>

--- a/Resources/README-zh.md
+++ b/Resources/README-zh.md
@@ -22,7 +22,7 @@
 
 | 功能 | OpenInTerminal | OpenInTerminal-Lite & OpenInEditor-Lite |
 | --- | --- | --- |
-| 支持 终端, [iTerm](https://www.iterm2.com/), [Hyper](https://github.com/zeit/hyper) 和 [Alacritty](https://github.com/jwilm/alacritty) | ✅ | ✅ |
+| 支持 终端, [iTerm](https://www.iterm2.com/)， [Hyper](https://github.com/zeit/hyper)， [Alacritty](https://github.com/jwilm/alacritty) 和 [Kitty](https://sw.kovidgoyal.net/kitty/) | ✅ | ✅ |
 | 支持 文本编辑, [Visual Studio Code](https://code.visualstudio.com/), [VSCode Insiders](https://code.visualstudio.com/insiders/), [Atom](https://atom.io/), [Sublime Text](https://www.sublimetext.com/), [VSCodium](https://github.com/VSCodium/vscodium), [BBEdit](https://www.barebones.com/products/bbedit/)，[TextMate](https://macromates.com)，[CotEditor](https://coteditor.com/)，[MacVim](https://github.com/macvim-dev/macvim) 和 [JetBrains](https://www.jetbrains.com/)(AppCode, CLion, GoLand, IntelliJ IDEA, PhpStorm, PyCharm, RubyMine, WebStorm) | ✅ | ✅ |
 | 设置为打开新的窗口或者标签页 | ✅ | ✅ |
 | 支持中文，英语，法语，俄语，意大利语和西班牙语 | ✅ | ✅ |


### PR DESCRIPTION
## Summary of this pull request

add support for kitty terminal

[kitty - the fast, featureful, GPU based terminal emulator](https://sw.kovidgoyal.net/kitty/)

## Does this solve an existing issue? If so, add a link to it

## Steps to test this feature

```
brew cask install kitty
defaults write wang.jianing.app.OpenInEditor-Lite OIT_EditorBundleIdentifier Kitty
```

## Screenshots

## Additional info

Currently, to select default terminal in openInTerminal-Lite has a some limit (only some of terminals works).
Maybe another way to select it? 
