### PR TITLE
针对编辑器打开功能优化（只测试了 VSCode

### DIFF
--- a/OpenInTerminalCore/Editors/EditorType.swift
+++ b/OpenInTerminalCore/Editors/EditorType.swift
@@ -209,6 +209,18 @@ public extension EditorType {
 extension EditorType: Scriptable {
     
     public func getScript() -> String {
+        if (self == .vscode) {
+            let script = """
+            on openVSCode(command)
+                tell application "Finder"
+                    activate
+                    do shell script command
+                end tell
+            end openVSCode
+            """
+            
+            return script
+        }
         let escapedName = self.fullName.nameSpaceEscaped
         
         let script = """

--- a/OpenInTerminalCore/Terminals/TerminalApps/iTermApp.swift
+++ b/OpenInTerminalCore/Terminals/TerminalApps/iTermApp.swift
@@ -37,7 +37,7 @@ extension String {
     
     // FIXME: if path contains "\" or """, application will crash.
     // Special symbols have been tested, except for backslashes and double quotes.
-    var specialCharEscaped: String {
+    public var specialCharEscaped: String {
         
         var result = ""
         let set: [Character] = [" ", "(", ")", "&", "|", ";",
@@ -46,6 +46,22 @@ extension String {
         for char in self {
             if set.contains(char) {
                 result += "\\\\"
+            }
+            result.append(char)
+        }
+        
+        return result
+    }
+    
+    public var specialCharEscaped2: String {
+        
+        var result = ""
+        let set: [Character] = [" ", "(", ")", "&", "|", ";",
+                                "\"", "'", "<", ">", "`"]
+        
+        for char in self {
+            if set.contains(char) {
+                result += "\\"
             }
             result.append(char)
         }

--- a/OpenInTerminalFinderExtension/FinderSync.swift
+++ b/OpenInTerminalFinderExtension/FinderSync.swift
@@ -192,10 +192,10 @@ class FinderSync: FIFinderSync {
             var path = "open -a Visual\\ Studio\\ Code"
             if let items = FIFinderSyncController.default().selectedItemURLs(), items.count > 0 {
                 items.forEach { (url) in
-                    path += " \(url.path)"
+                    path += " \(url.path.specialCharEscaped2)"
                 }
             } else if let url = FIFinderSyncController.default().targetedURL() {
-                path = url.path
+                path = url.path.specialCharEscaped2
             } else {
                 return
             }


### PR DESCRIPTION
一直以来存在的一个问题，在 Finder 中左键选中文件，右键选择在编辑器中打开后可以正常打开这个文件。

但是如果不选中，直接在文件上右键选择在编辑器中打开这时候打开的是文件所在目录，而非文件本身。（5 月份的时候发邮件反馈过，等到现在，实在等不及了🤣）

个人对 script 不熟，在网上找了资料，重写了 vscode 的 scpt 文件。

作者可以看一下，如果接受这个优化可以根据原结构编写一下，我这里只简单的 if 了一下。

顺便拷贝路径功能，之前只拷贝了第一个，我顺便改成了拷贝所有路径，回车拼接。