### PR TITLE
Fix installation instructions

### DIFF
--- a/Resources/README-Lite-zh.md
+++ b/Resources/README-Lite-zh.md
@@ -30,9 +30,9 @@
 1. 运行以下命令
 
 ```
-brew cask install openinterminal-lite
+brew install --cask openinterminal-lite
 # 或者
-brew cask install openineditor-lite
+brew install --cask openineditor-lite
 ```
 
 2. 在 `应用程序` 文件夹中，按住 `Cmd` 键，然后将应用拖到访达工具栏中。

--- a/Resources/README-Lite.md
+++ b/Resources/README-Lite.md
@@ -29,9 +29,9 @@ English | [中文说明](./README-Lite-zh.md)
 1. Run the following command
 
 ```
-brew cask install openinterminal-lite
+brew install --cask openinterminal-lite
 # or
-brew cask install openineditor-lite
+brew install --cask openineditor-lite
 ```
 
 2. In `/Applications` folder, hold down the `Cmd` key and drag the app into Finder Toolbar.

--- a/Resources/README-zh.md
+++ b/Resources/README-zh.md
@@ -48,7 +48,7 @@
 #### a) Homebrew
 
 ```
-brew cask install openinterminal
+brew install --cask openinterminal
 ```
 
 #### b) 手动


### PR DESCRIPTION
## Summary of this pull request

Calling `brew cask install` is disabled in latest Homebrew.

Same as  #123 .
