### PR TITLE
feat(Core): Support open kitty in new tab

### DIFF
--- a/OpenInTerminalCore/App.swift
+++ b/OpenInTerminalCore/App.swift
@@ -90,8 +90,7 @@ extension App: Openable {
 //                }
             } else {
                 // this app is general
-                var openCommand = ScriptManager.shared.getOpenCommand(self, escapeCount: 2)
-                openCommand += " " + path.specialCharEscaped(2)
+                let openCommand = ScriptManager.shared.getOpenCommand(self, path: path, escapeCount: 2)
                 let source = """
                 do shell script "\(openCommand)"
                 """
@@ -108,10 +107,8 @@ extension App: Openable {
                 paths.append(desktopPath)
             }
             
-            var openCommand = ScriptManager.shared.getOpenCommand(self, escapeCount: 2)
-            paths.forEach {
-                openCommand += " \($0.specialCharEscaped(2))"
-            }
+            let path = paths.joined(separator: " ")
+            let openCommand = ScriptManager.shared.getOpenCommand(self, path: path, escapeCount: 2)
             let source = """
             do shell script "\(openCommand)"
             """
@@ -134,8 +131,7 @@ extension App: Openable {
                 url.deleteLastPathComponent()
             }
             // get open command, e.g. "open -a Terminal /Users/user/Desktop/test\ folder"
-            var openCommand = ScriptManager.shared.getOpenCommand(self)
-            openCommand += " " + url.path.specialCharEscaped()
+            let openCommand = ScriptManager.shared.getOpenCommand(self, path: url.path)
             // script
             guard let scriptURL = ScriptManager.shared.getScriptURL(with: Constants.generalScript) else { return }
 //            // handle exceptional case
@@ -158,12 +154,10 @@ extension App: Openable {
             }
         case .editor:
             // get open command, e.g. "open -a TextEdit /Users/user/Desktop/test\ folder /Users/user/Documents"
-            var openCommand = ScriptManager.shared.getOpenCommand(self)
-            urls.map {
+            let path = urls.map {
                 $0.path
-            }.forEach {
-                openCommand += " " + $0.specialCharEscaped()
-            }
+            }.joined(separator: " ")
+            let openCommand = ScriptManager.shared.getOpenCommand(self, path: path)
             // script
             guard let scriptURL = ScriptManager.shared.getScriptURL(with: Constants.generalScript) else { return }
             // excute

--- a/OpenInTerminalCore/Defaults.swift
+++ b/OpenInTerminalCore/Defaults.swift
@@ -45,6 +45,7 @@ public extension DefaultsKeys {
     // Preferences - Custom
     static let terminalNewOption = DefaultsKey<String>("TerminalNewOption")
     static let iTermNewOption = DefaultsKey<String>("iTermNewOption")
+    static let kittyNewOption = DefaultsKey<String>("kittyNewOption")
     static let customMenuOptions = DefaultsKey<Data>("CustomMenuOptions")
     static let customMenuApplyToToolbar = DefaultsKey<Bool>("CustomMenuApplyToToolbar")
     static let customMenuApplyToContext = DefaultsKey<Bool>("CustomMenuApplyToContext")

--- a/OpenInTerminalCore/DefaultsManager.swift
+++ b/OpenInTerminalCore/DefaultsManager.swift
@@ -129,6 +129,8 @@ public class DefaultsManager {
 //            option = Defaults[.terminalNewOption]
         case .iTerm:
             option = Defaults[.iTermNewOption]
+        case .kitty:
+            option = Defaults[.kittyNewOption]
         default:
             return nil
         }
@@ -154,6 +156,8 @@ public class DefaultsManager {
             if error != nil {
                 logw("Setting iTerm new option failed: \(String(describing: error))")
             }
+        case .kitty:
+            Defaults[.kittyNewOption] = newOption.rawValue
         default:
             return
         }
@@ -251,6 +255,7 @@ public class DefaultsManager {
         defaultEditor = SupportedApps.textEdit.app
         setNewOption(.terminal, .window)
         setNewOption(.iTerm, .window)
+        setNewOption(.kitty, .tab)
         isCustomMenuApplyToToolbar = false
         isCustomMenuApplyToContext = false
         customMenuIconOption = .no

--- a/OpenInTerminalCore/ScriptManager.swift
+++ b/OpenInTerminalCore/ScriptManager.swift
@@ -16,13 +16,20 @@ public class ScriptManager {
     // MARK: - Get AppleScript
     
     /// get `open` command
-    public func getOpenCommand(_ app: App, escapeCount: Int = 1) -> String {
+    public func getOpenCommand(_ app: App, path: String = "", escapeCount: Int = 1) -> String {
+        let escapedPath = path.specialCharEscaped(escapeCount)
         if SupportedApps.is(app, is: .alacritty) {
-            return "open -na Alacritty --args --working-directory"
+            return "open -na Alacritty --args --working-directory \(escapedPath)"
         } else if SupportedApps.is(app, is: .kitty) {
-            return "open -na kitty --args --directory"
+            let newOption = DefaultsManager.shared.getNewOption(.kitty) ?? .tab
+            switch newOption {
+            case .tab:
+                return "zsh -c '/Applications/kitty.app/Contents/MacOS/kitty @ --to unix:/tmp/openkittytab launch --type=tab --cwd \(escapedPath) zsh || /Applications/kitty.app/Contents/MacOS/kitty --listen-on=unix:/tmp/openkittytab -o allow_remote_control=yes -d \(escapedPath) > /dev/null 2>&1 &'"
+            case .window:
+                return "open -na kitty --args --directory \(escapedPath)"
+            }
         } else {
-            return "open -a \(app.name.nameSpaceEscaped(escapeCount))"
+            return "open -a \(app.name.nameSpaceEscaped(escapeCount)) \(escapedPath)"
         }
     }
     


### PR DESCRIPTION
## Summary of this pull request
add an option to open kitty in new tab and make it default

## Does this solve an existing issue? If so, add a link to it
open kitty in new window will clutter the dock pretty quick, as every window takes its own icon space at the system dock

## Steps to test this feature
"Open in kitty" will default to open a directory in new tab

## Screenshots

## Additional info
