### PR TITLE
feat(Core): activate kitty window when open a tab

### DIFF
--- a/OpenInTerminalCore/ScriptManager.swift
+++ b/OpenInTerminalCore/ScriptManager.swift
@@ -24,7 +24,7 @@ public class ScriptManager {
             let newOption = DefaultsManager.shared.getNewOption(.kitty) ?? .tab
             switch newOption {
             case .tab:
-                return "zsh -c '/Applications/kitty.app/Contents/MacOS/kitty @ --to unix:/tmp/openkittytab launch --type=tab --cwd \(escapedPath) zsh || /Applications/kitty.app/Contents/MacOS/kitty --listen-on=unix:/tmp/openkittytab -o allow_remote_control=yes -d \(escapedPath) > /dev/null 2>&1 &'"
+                return "zsh -c '/Applications/kitty.app/Contents/MacOS/kitty @ --to unix:/tmp/openkittytab launch --type=tab --cwd \(escapedPath) zsh && /Applications/kitty.app/Contents/MacOS/kitty @ --to unix:/tmp/openkittytab focus-window || /Applications/kitty.app/Contents/MacOS/kitty --listen-on=unix:/tmp/openkittytab -o allow_remote_control=yes -d \(escapedPath) > /dev/null 2>&1 &'"
             case .window:
                 return "open -na kitty --args --directory \(escapedPath)"
             }


### PR DESCRIPTION
## Summary of this pull request
Activate kitty window when openning a directory in a new tab

## Does this solve an existing issue? If so, add a link to it
Fix prev commit which won't activate kitty window when openning a tab

## Steps to test this feature

## Screenshots

## Additional info
