### PR TITLE
Add support for nix-darwin's Nix Apps directory

### DIFF
--- a/OpenInTerminalCore/FinderManager.swift
+++ b/OpenInTerminalCore/FinderManager.swift
@@ -222,7 +222,22 @@ public class FinderManager {
                         }
                         // add to applications
                         if baseName.hasSuffix(".app") {
-                            let appName = fileURL.deletingPathExtension().lastPathComponent
+                            var appName = fileURL.deletingPathExtension().lastPathComponent
+                            
+                            // nixpkgs fixes
+                            do {
+                                // iTerm is installed as iTerm2.app
+                                if appName == "iTerm2" {
+                                    appName = "iTerm"
+                                }
+                                // IntelliJ IDEA and PyCharm community edition have CE appended
+                                else if appName == "IntelliJ IDEA CE" {
+                                    appName = "IntelliJ IDEA"
+                                } else if appName == "PyCharm CE" {
+                                    appName = "PyCharm"
+                                }
+                            }
+                            
                             applications.insert(appName)
                             continue
                         }

--- a/OpenInTerminalCore/FinderManager.swift
+++ b/OpenInTerminalCore/FinderManager.swift
@@ -211,7 +211,7 @@ public class FinderManager {
                     break
                 }
                 
-                var tmpDirs = searchDirs
+                var tmpSearchDirs = searchDirs
                 for currentDir in searchDirs {
                     let fileURLs = try fileManager.contentsOfDirectory(at: currentDir, includingPropertiesForKeys: nil)
                     for fileURL in fileURLs {
@@ -238,9 +238,14 @@ public class FinderManager {
                                     try (fileURL as NSURL).getResourceValue(&isAlias, forKey: URLResourceKey.isAliasFileKey)
                                 } catch _ {}
                                 if let isAlias = isAlias as? Bool {
+                                    // for nix-darwin users, applications installed through nix will be installed into a symlinked (alias) directory called "Nix Apps"
+                                    if fileURL.lastPathComponent == "Nix Apps" {
+                                        // symlink needs to be resolved first
+                                        tmpSearchDirs.insert(URL(string: try fileManager.destinationOfSymbolicLink(atPath: fileURL.absoluteString.removingPercentEncoding!.replacingOccurrences(of: "file://", with: "")))!)
+                                    }
                                     // skip alias directory
-                                    if !isAlias {
-                                        tmpDirs.insert(fileURL)
+                                    else if !isAlias {
+                                        tmpSearchDirs.insert(fileURL)
                                     }
                                 }
                             } else {
@@ -250,9 +255,9 @@ public class FinderManager {
                             // file does not exist
                         }
                     }
-                    tmpDirs.remove(currentDir)
+                    tmpSearchDirs.remove(currentDir)
                 }
-                searchDirs = tmpDirs
+                searchDirs = tmpSearchDirs
             }
             
         } catch {


### PR DESCRIPTION
## Summary of this pull request

This PR adds support for apps installed via nix-darwin. nix-darwin installs apps into a symlinked directory at `/Applications/Nix Apps`. Since OpenInTerminal ignores aliases/symlinks, these apps were previously not picked up.

It also includes fixes for nixpkgs's iTerm, IntelliJ IDEA Community Edition, and PyCharm Community Edition packages. nix installs iTerm as `iTerm2.app`, and IntelliJ and PyCharm with `CE` appended to the app name. OpenInTerminal did not previously recognize these names.

## Does this solve an existing issue? If so, add a link to it

#183, partially. It does not add support for nix installed apps without a .app

## Steps to test this feature

1. Install [nix-darwin](https://github.com/LnL7/nix-darwin)
2. Install an app by adding it to your `environment.systemPackages`, for example `iterm2`

## Screenshots

\-

## Additional info

\-