### PR TITLE
Show all supported terminals in OpenInTerminalLite first-launch prompt

### DIFF
--- a/OpenInTerminalCore/AppManager.swift
+++ b/OpenInTerminalCore/AppManager.swift
@@ -19,20 +19,20 @@ public class AppManager {
         // Add button and avoid the focus ring
         let cancelString = NSLocalizedString("general.cancel", comment: "Cancel")
         alert.addButton(withTitle: cancelString).refusesFirstResponder = true
-        alert.addButton(withTitle: SupportedApps.terminal.name).refusesFirstResponder = true
-        alert.addButton(withTitle: SupportedApps.iTerm.name).refusesFirstResponder = true
-        alert.addButton(withTitle: SupportedApps.hyper.name).refusesFirstResponder = true
-        let modalResult = alert.runModal()
-        switch modalResult {
-        case .alertFirstButtonReturn:
-            return nil
-        case .alertSecondButtonReturn:
-            return SupportedApps.terminal.app
-        case .alertThirdButtonReturn:
-            return SupportedApps.iTerm.app
-        default:
-            return SupportedApps.hyper.app
+        
+        let terminals = Array(SupportedApps.terminals.reversed())
+        for app in terminals {
+            alert.addButton(withTitle: app.name).refusesFirstResponder = true
         }
+        let modalResult = alert.runModal()
+        
+        let selectedAppIndex = modalResult.rawValue - NSApplication.ModalResponse.alertSecondButtonReturn.rawValue
+        
+        if selectedAppIndex >= 0 && selectedAppIndex < terminals.count {
+            let selectedApp = terminals[selectedAppIndex].app
+            return selectedApp
+        }
+        return nil
     }
     
     public func pickEditorAlert() -> App? {


### PR DESCRIPTION
## Summary of this pull request
I want to use Ghostty with OpenInTerminalLite, but that wasn't supported by the UI.  I hacked Ghostty into one of the three options, but I figured there must be a way to make this work for everyone and their preferred terminal.  I found a helpful pointer here: https://stackoverflow.com/a/59245758

## Does this solve an existing issue? If so, add a link to it
N/A

## Steps to test this feature
Clear existing settings using `defaults delete wang.jianing.app.OpenInTerminal-Lite`, then run OpenInTerminal-Lite

## Screenshots
<img width="1342" height="265" alt="Screenshot 2025-07-28 at 12 38 04 PM" src="https://github.com/user-attachments/assets/ec4e5fcf-d781-4ea0-b960-d6c6552a57f8" />

## Additional info
