### PR TITLE
Add option to change global keyboard shortcuts to Finder only shortcuts.

### DIFF
--- a/OpenInTerminal/AppDelegate.swift
+++ b/OpenInTerminal/AppDelegate.swift
@@ -19,6 +19,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     @IBOutlet weak var statusBarMenu: NSMenu!
     
+    var terminalShortcutAction: ShortcutAction?
+    var editorShortcutAction: ShortcutAction?
+    var copyPathShortcutAction: ShortcutAction?
+    var areShortcutsRegistered = false
+    
     // MARK: - Lifecycle
     
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -57,6 +62,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             showPreferencesWindow()
         }
         return true
+    }
+    
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        if keyPath == Constants.Key.onlyActivateShortcutsInFinder {
+            updateShortcutRegistration()
+            return
+        }
+        
+        super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
     }
     
 }
@@ -149,12 +163,28 @@ extension AppDelegate {
         OpenNotifier.addObserver(observer: self,
                                  selector: #selector(copyPathToClipboard),
                                  notification: .copyPathToClipboard)
+        
+        Defaults.addObserver(self, 
+                             forKeyPath: Constants.Key.onlyActivateShortcutsInFinder, 
+                             options: .new, 
+                             context: nil)
+        NSWorkspace.shared.notificationCenter.addObserver(self, 
+                                                          selector: #selector(activeAppDidChange), 
+                                                          name: NSWorkspace.didActivateApplicationNotification, 
+                                                          object: nil)
     }
     
     func removeObserver() {
         OpenNotifier.removeObserver(observer: self, notification: .openDefaultTerminal)
         OpenNotifier.removeObserver(observer: self, notification: .openDefaultEditor)
         OpenNotifier.removeObserver(observer: self, notification: .copyPathToClipboard)
+        
+        Defaults.removeObserver(self, forKeyPath: Constants.Key.onlyActivateShortcutsInFinder)
+        NSWorkspace.shared.notificationCenter.removeObserver(self)
+    }
+    
+    @objc func activeAppDidChange(_ notification: Notification) {
+        updateShortcutRegistration()
     }
     
     // MARK: Notification Actions
@@ -243,26 +273,48 @@ extension AppDelegate {
     // MARK: - Global Shortcuts
     
     func bindShortcuts() {
-        let oitAction = ShortcutAction(keyPath: Constants.Key.defaultTerminalShortcut, of: Defaults) { _ in
+        terminalShortcutAction = ShortcutAction(keyPath: Constants.Key.defaultTerminalShortcut, of: Defaults) { _ in
             let appDelegate = NSApplication.shared.delegate as! AppDelegate
             appDelegate.openDefaultTerminal()
             return true
         }
-        GlobalShortcutMonitor.shared.addAction(oitAction, forKeyEvent: .down)
         
-        let oieAction = ShortcutAction(keyPath: Constants.Key.defaultEditorShortcut, of: Defaults) { _ in
+        editorShortcutAction = ShortcutAction(keyPath: Constants.Key.defaultEditorShortcut, of: Defaults) { _ in
             let appDelegate = NSApplication.shared.delegate as! AppDelegate
             appDelegate.openDefaultEditor()
             return true
         }
-        GlobalShortcutMonitor.shared.addAction(oieAction, forKeyEvent: .down)
         
-        let copyPathAction = ShortcutAction(keyPath: Constants.Key.copyPathShortcut, of: Defaults) { _ in
+        copyPathShortcutAction = ShortcutAction(keyPath: Constants.Key.copyPathShortcut, of: Defaults) { _ in
             let appDelegate = NSApplication.shared.delegate as! AppDelegate
             appDelegate.copyPathToClipboard()
             return true
         }
-        GlobalShortcutMonitor.shared.addAction(copyPathAction, forKeyEvent: .down)
+        
+        updateShortcutRegistration()
+    }
+    
+    func updateShortcutRegistration() {
+        let shouldRegister: Bool
+        if DefaultsManager.shared.shouldOnlyActivateShortcutsInFinder {
+            shouldRegister = NSWorkspace.shared.frontmostApplication?.bundleIdentifier == "com.apple.finder"
+        } else {
+            shouldRegister = true
+        }
+        
+        guard shouldRegister != areShortcutsRegistered else { return }
+        
+        if shouldRegister {
+            if let action = terminalShortcutAction, action.shortcut != nil { GlobalShortcutMonitor.shared.addAction(action, forKeyEvent: .down) }
+            if let action = editorShortcutAction, action.shortcut != nil { GlobalShortcutMonitor.shared.addAction(action, forKeyEvent: .down) }
+            if let action = copyPathShortcutAction, action.shortcut != nil { GlobalShortcutMonitor.shared.addAction(action, forKeyEvent: .down) }
+        } else {
+            if let action = terminalShortcutAction, action.shortcut != nil { GlobalShortcutMonitor.shared.removeAction(action, forKeyEvent: .down) }
+            if let action = editorShortcutAction, action.shortcut != nil { GlobalShortcutMonitor.shared.removeAction(action, forKeyEvent: .down) }
+            if let action = copyPathShortcutAction, action.shortcut != nil { GlobalShortcutMonitor.shared.removeAction(action, forKeyEvent: .down) }
+        }
+        
+        areShortcutsRegistered = shouldRegister
     }
 }
 

--- a/OpenInTerminal/Constants.swift
+++ b/OpenInTerminal/Constants.swift
@@ -26,6 +26,7 @@ struct Constants {
         static let defaultTerminalShortcut = "OIT_DefaultTerminalShortcut"
         static let defaultEditorShortcut = "OIT_DefaultEditorShortcut"
         static let copyPathShortcut = "OIT_CopyPathShortcut"
+        static let onlyActivateShortcutsInFinder = "OnlyActivateShortcutsInFinder"
     }
     
     static let PreferencesStoryboard = NSStoryboard(name: "Preferences", bundle: nil)

--- a/OpenInTerminal/PreferencesWindow/AdvancedPreferencesViewController.swift
+++ b/OpenInTerminal/PreferencesWindow/AdvancedPreferencesViewController.swift
@@ -16,6 +16,7 @@ class AdvancedPreferencesViewController: PreferencesViewController {
     @IBOutlet weak var defaultTerminalShortcut: RecorderControl!
     @IBOutlet weak var defaultEditorShortcut: RecorderControl!
     @IBOutlet weak var copyPathShortcut: RecorderControl!
+    @IBOutlet weak var finderOnlyCheckbox: NSButton!
     @IBOutlet weak var resetPreferencesButton: NSButton!
     
     // MARK: Lifecycle
@@ -26,6 +27,7 @@ class AdvancedPreferencesViewController: PreferencesViewController {
         defaultTerminalShortcut.bind(.value, to: Defaults, withKeyPath: Constants.Key.defaultTerminalShortcut)
         defaultEditorShortcut.bind(.value, to: Defaults, withKeyPath: Constants.Key.defaultEditorShortcut)
         copyPathShortcut.bind(.value, to: Defaults, withKeyPath: Constants.Key.copyPathShortcut)
+        finderOnlyCheckbox.bind(.value, to: Defaults, withKeyPath: Constants.Key.onlyActivateShortcutsInFinder)
     }
     
     

--- a/OpenInTerminal/PreferencesWindow/Base.lproj/Preferences.storyboard
+++ b/OpenInTerminal/PreferencesWindow/Base.lproj/Preferences.storyboard
@@ -834,6 +834,13 @@
                                             <real value="3.4028234663852886e+38"/>
                                         </customSpacing>
                                     </stackView>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Fnd-On-Chk">
+                                        <rect key="frame" x="-2" y="113" width="216" height="18"/>
+                                        <buttonCell key="cell" type="check" title="Only activate shortcuts in Finder" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Cel-Fnd-On">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                    </button>
                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0uu-e7-m1W">
                                         <rect key="frame" x="-2" y="102" width="40" height="16"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" title="Reset" id="jcs-Ou-OZ2">
@@ -894,8 +901,10 @@
                                     <integer value="1000"/>
                                     <integer value="1000"/>
                                     <integer value="1000"/>
+                                    <integer value="1000"/>
                                 </visibilityPriorities>
                                 <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
@@ -917,6 +926,7 @@
                     </view>
                     <connections>
                         <outlet property="copyPathShortcut" destination="WBc-IR-x3y" id="tBb-rV-Cyb"/>
+                        <outlet property="finderOnlyCheckbox" destination="Fnd-On-Chk" id="Out-Fnd-Chk"/>
                         <outlet property="defaultEditorShortcut" destination="TL3-ol-bGi" id="F42-pz-UNZ"/>
                         <outlet property="defaultTerminalShortcut" destination="9ud-I5-Kam" id="l0e-EE-0qn"/>
                         <outlet property="resetPreferencesButton" destination="qri-L6-ZRL" id="cHB-aG-Whi"/>

--- a/OpenInTerminal/en.lproj/Localizable.strings
+++ b/OpenInTerminal/en.lproj/Localizable.strings
@@ -39,4 +39,4 @@
 "pref.custom.menu.manually_select" = "Manually Select From Finder";
 "pref.custom.menu.manually_input" = "Manually Input";
 
-
+"pref.shortcuts_finder_only" = "Only activate shortcuts in Finder";

--- a/OpenInTerminalCore/Defaults.swift
+++ b/OpenInTerminalCore/Defaults.swift
@@ -52,6 +52,7 @@ public extension DefaultsKeys {
     static let customMenuIconOption = DefaultsKey<String>("CustomMenuIconOption")
     static let pathEscapeOption = DefaultsKey<Bool>("PathEscapeOption")
     static let kittyCommand = DefaultsKey<String>("KittyCommand")
+    static let onlyActivateShortcutsInFinder = DefaultsKey<Bool>("OnlyActivateShortcutsInFinder")
     static let neovimCommand = DefaultsKey<String>("NeovimCommand")
     
     // for Lite

--- a/OpenInTerminalCore/DefaultsManager.swift
+++ b/OpenInTerminalCore/DefaultsManager.swift
@@ -74,6 +74,16 @@ public class DefaultsManager {
         }
     }
     
+    public var shouldOnlyActivateShortcutsInFinder: Bool {
+        get {
+            return Defaults[.onlyActivateShortcutsInFinder]
+        }
+        
+        set {
+            Defaults[.onlyActivateShortcutsInFinder] = newValue
+        }
+    }
+    
     public var defaultTerminal: App? {
         get {
             guard let terminalName = Defaults[.defaultTerminal] else { return nil }


### PR DESCRIPTION
## Summary
This pull request adds the feature to make keyboard shortcuts activate in Finder only.
A **"Only activate shortcuts in Finder"** checkbox option is added under the **keyboard shortcuts** menu.

<img width="380" height="379" alt="Screenshot 2025-12-30 at 16 34 01" src="https://github.com/user-attachments/assets/7ead5d8b-dff3-4313-83b9-78753770054f" />


When the option is enabled, the keyboard shortcuts are ONLY activated when Finder is the front most application, as such we could avoid clashing of shortcuts with other programs.

For example you could have a hotkey to copy the path of the active file in your IDE, and set the same hotkey for "Copy path in Clipboard" in **OpenInTerminal**. That way you could use the same hotkey to perform the same action across Finder and the IDE.

Before adding the feature this was NOT possible, because **OpenInTerminal** would always "consume" the hotkey and the IDE's hotkey could not be triggered.


## Existing issue
This is related to issue #243.

