### PR TITLE
docs: fix broken links in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <img width="80%" src="https://user-images.githubusercontent.com/11001224/104892170-d18f2b80-59ac-11eb-96b1-0293acfde4e5.png"><br/><br/>
-  English | <a href="./Resources/README-zh.md">中文</a> | <a href="./Resources/README-tr.md">Türkçe</a> | <a href="./Resources/README-de.md">Deutsch</a>
+  <a href="./README.md">English</a> | <a href="./Resources/README-zh.md">中文</a> | <a href="./Resources/README-tr.md">Türkçe</a> | <a href="./Resources/README-de.md">Deutsch</a>
 </div>
 
 ## How to use 🚀

--- a/Resources/README-Lite-de.md
+++ b/Resources/README-Lite-de.md
@@ -6,7 +6,7 @@
   <a href="https://travis-ci.org/Ji4n1ng/OpenInTerminal"><img src="https://img.shields.io/travis/Ji4n1ng/OpenInTerminal.svg"></a>
 </p>
 
-[English](./README-Lite.md) | [中文说明](./README-Lite-zh.md) | Deutsch
+[English](./README-Lite.md) | [中文说明](./README-Lite-zh.md) | [Deutsch](./README-Lite-de.md)
 
 ## Verwendung 🚀
 

--- a/Resources/README-Lite-zh.md
+++ b/Resources/README-Lite-zh.md
@@ -1,6 +1,6 @@
 <div align="center">
   <img width="100%" src="https://user-images.githubusercontent.com/11001224/104892184-d522b280-59ac-11eb-9c06-5ffd044dce7d.png"><br/><br/>
-  <a href="./README-Lite.md">English</a> | 中文 | <a href="./README-Lite-de.md">Deutsch</a>
+  <a href="./README-Lite.md">English</a> | <a href="./README-Lite-zh.md">中文</a> | <a href="./README-Lite-de.md">Deutsch</a>
 </div>
 
 ## 如何使用 🚀

--- a/Resources/README-Lite.md
+++ b/Resources/README-Lite.md
@@ -1,6 +1,6 @@
 <div align="center">
   <img width="100%" src="https://user-images.githubusercontent.com/11001224/104892184-d522b280-59ac-11eb-9c06-5ffd044dce7d.png"><br/><br/>
-  English | <a href="./README-Lite-zh.md">中文</a> | <a href="./README-Lite-de.md">Deutsch</a>
+  <a href="./README-Lite.md">English</a> | <a href="./README-Lite-zh.md">中文</a> | <a href="./README-Lite-de.md">Deutsch</a>
 </div>
 
 ## How to use 🚀

--- a/Resources/README-de.md
+++ b/Resources/README-de.md
@@ -6,9 +6,9 @@
   <a href="https://travis-ci.org/Ji4n1ng/OpenInTerminal"><img src="https://img.shields.io/travis/Ji4n1ng/OpenInTerminal.svg"></a>
 </p>
 
-[English](../README.md) | [OpenInTerminal 中文说明](./Resources/README-zh.md) | [OpenInTerminal Türkçe](./Resources/README-tr.md) | OpenInTerminal Deutsch
+[English](../README.md) | [OpenInTerminal 中文说明](./README-zh.md) | [OpenInTerminal Türkçe](./README-tr.md) | [OpenInTerminal Deutsch](./README-de.md)
 
-[OpenInTerminal-Lite English](./Resources/README-Lite.md) | [OpenInTerminal-Lite 中文说明](./Resources/README-Lite-zh.md) | [OpenInTerminal-Lite Deutsch](./Resources/README-Lite-de.md)
+[OpenInTerminal-Lite English](./README-Lite.md) | [OpenInTerminal-Lite 中文说明](./README-Lite-zh.md) | [OpenInTerminal-Lite Deutsch](./README-Lite-de.md)
 
 ## Verwendung 🚀
 
@@ -36,7 +36,7 @@ Ich bevorzuge `OpenInTerminal-Lite`, bei dem man nur einmal klicken muss, um die
 
 Für `OpenInTerminal-Lite` Nutzer:
 
-Bitte lesen Sie das Dokument: [OpenInTerminal-Lite English](./Resources/README-Lite.md) | [OpenInTerminal-Lite 中文说明](./Resources/README-Lite-zh.md) | [OpenInTerminal-Lite Türkçe](./Resources/README-Lite-tr.md) | [OpenInTerminal-Lite Deutsch](./Resources/README-Lite-de.md)
+Bitte lesen Sie das Dokument: [OpenInTerminal-Lite English](./README-Lite.md) | [OpenInTerminal-Lite 中文说明](./README-Lite-zh.md) | [OpenInTerminal-Lite Türkçe](./README-Lite-tr.md) | [OpenInTerminal-Lite Deutsch](./README-Lite-de.md)
 
 ## Installation 🖥
 
@@ -74,7 +74,7 @@ Danke für Ihre Unterstützung!
 
 | PayPal | AliPay | WeChat Pay |
 | --- | --- | --- |
-| [paypal.me/ji4ning](https://www.paypal.me/ji4ning) | <img src="./Resources/Support-Alipay.jpg" width="50%"> | <img src="./Resources/Support-WeChatPay.jpg" width="50%"> |
+| [paypal.me/ji4ning](https://www.paypal.me/ji4ning) | <img src="./Support-Alipay.jpg" width="50%"> | <img src="./Support-WeChatPay.jpg" width="50%"> |
 
 ## FAQ ❓
 

--- a/Resources/README-de.md
+++ b/Resources/README-de.md
@@ -36,7 +36,7 @@ Ich bevorzuge `OpenInTerminal-Lite`, bei dem man nur einmal klicken muss, um die
 
 Für `OpenInTerminal-Lite` Nutzer:
 
-Bitte lesen Sie das Dokument: [OpenInTerminal-Lite English](./README-Lite.md) | [OpenInTerminal-Lite 中文说明](./README-Lite-zh.md) | [OpenInTerminal-Lite Türkçe](./README-Lite-tr.md) | [OpenInTerminal-Lite Deutsch](./README-Lite-de.md)
+Bitte lesen Sie das Dokument: [OpenInTerminal-Lite English](./README-Lite.md) | [OpenInTerminal-Lite 中文说明](./README-Lite-zh.md) | [OpenInTerminal-Lite Deutsch](./README-Lite-de.md)
 
 ## Installation 🖥
 

--- a/Resources/README-tr.md
+++ b/Resources/README-tr.md
@@ -6,9 +6,9 @@
   <a href="https://travis-ci.org/Ji4n1ng/OpenInTerminal"><img src="https://img.shields.io/travis/Ji4n1ng/OpenInTerminal.svg"></a>
 </p>
 
-English | [OpenInTerminal 中文说明](./Resources/README-zh.md) | [OpenInTerminal Türkçe](./Resources/README-tr.md) 
+[English](../README.md) | [OpenInTerminal 中文说明](./README-zh.md) | [OpenInTerminal Türkçe](./README-tr.md) | [OpenInTerminal Deutsch](./README-de.md)
 
-[OpenInTerminal-Lite English](./Resources/README-Lite.md) | [OpenInTerminal-Lite 中文说明](./Resources/README-Lite-zh.md) | [OpenInTerminal-Lite Türkçe](./Resources/README-Lite-tr.md)
+[OpenInTerminal-Lite English](./README-Lite.md) | [OpenInTerminal-Lite 中文说明](./README-Lite-zh.md) | [OpenInTerminal-Lite Türkçe](./README-Lite-tr.md) | [OpenInTerminal-Lite Deutsch](./README-Lite-de.md)
 
 ## Nasıl kullanılır 🚀
 
@@ -36,7 +36,7 @@ Hangisini seçmeliyim? İki sürüm de benim için değerli. Eğer daha güçlü
 
 `OpenInTerminal-Lite` kullanıcıları için:
 
-İlişkin döküman: [OpenInTerminal-Lite English](./Resources/README-Lite.md) | [OpenInTerminal-Lite 中文说明](./Resources/README-Lite-zh.md) | [OpenInTerminal-Lite Türkçe](./Resources/README-Lite-tr.md)
+İlişkin döküman: [OpenInTerminal-Lite English](./README-Lite.md) | [OpenInTerminal-Lite 中文说明](./README-Lite-zh.md) | [OpenInTerminal-Lite Türkçe](./README-Lite-tr.md) | [OpenInTerminal-Lite Deutsch](./README-Lite-de.md)
 
 ## Nasıl Yüklenir 🖥
 

--- a/Resources/README-tr.md
+++ b/Resources/README-tr.md
@@ -8,7 +8,7 @@
 
 [English](../README.md) | [OpenInTerminal 中文说明](./README-zh.md) | [OpenInTerminal Türkçe](./README-tr.md) | [OpenInTerminal Deutsch](./README-de.md)
 
-[OpenInTerminal-Lite English](./README-Lite.md) | [OpenInTerminal-Lite 中文说明](./README-Lite-zh.md) | [OpenInTerminal-Lite Türkçe](./README-Lite-tr.md) | [OpenInTerminal-Lite Deutsch](./README-Lite-de.md)
+[OpenInTerminal-Lite English](./README-Lite.md) | [OpenInTerminal-Lite 中文说明](./README-Lite-zh.md) | [OpenInTerminal-Lite Deutsch](./README-Lite-de.md)
 
 ## Nasıl kullanılır 🚀
 
@@ -36,7 +36,7 @@ Hangisini seçmeliyim? İki sürüm de benim için değerli. Eğer daha güçlü
 
 `OpenInTerminal-Lite` kullanıcıları için:
 
-İlişkin döküman: [OpenInTerminal-Lite English](./README-Lite.md) | [OpenInTerminal-Lite 中文说明](./README-Lite-zh.md) | [OpenInTerminal-Lite Türkçe](./README-Lite-tr.md) | [OpenInTerminal-Lite Deutsch](./README-Lite-de.md)
+İlişkin döküman: [OpenInTerminal-Lite English](./README-Lite.md) | [OpenInTerminal-Lite 中文说明](./README-Lite-zh.md) | [OpenInTerminal-Lite Deutsch](./README-Lite-de.md)
 
 ## Nasıl Yüklenir 🖥
 

--- a/Resources/README-zh.md
+++ b/Resources/README-zh.md
@@ -41,7 +41,7 @@ brew install --cask openinterminal
 
 ## 配置和常见问题 ⚙️
 
-请看文档 [配置](./Resources/README-Config-zh.md)
+请看文档 [配置](./README-Config-zh.md)
 
 ## 支持 ❤️
 

--- a/Resources/README-zh.md
+++ b/Resources/README-zh.md
@@ -1,6 +1,6 @@
 <div align="center">
   <img width="80%" src="https://user-images.githubusercontent.com/11001224/104892170-d18f2b80-59ac-11eb-96b1-0293acfde4e5.png"><br/><br/>
-  <a href="../README.md">English</a> | 中文
+  <a href="../README.md">English</a> | <a href="./README-zh.md">中文</a>
 </div>
 
 ## 如何使用 🚀


### PR DESCRIPTION
## Summary of this pull request
Fixed broken language switch links and internal reference links across all README documentation files.
  - Fixed language switch links in root `README.md`
  - Fixed cross-reference links in `README-Lite-*.md` series
  - Fixed documentation path references in `README-de.md` and `README-tr.md`
  - Fixed configuration document link in `README-zh.md`
  - Standardized all language switch link formats to ensure correct file paths
  - 
## Does this solve an existing issue? If so, add a link to it

## Steps to test this feature

## Screenshots

## Additional info
  ## Impact
  - Documentation link fixes only, no code logic changes
  - Affected files:
    - `README.md`
    - `Resources/README-*.md` (multiple language versions)
    - `Resources/README-Lite-*.md` (multiple language versions)