### PR TITLE
Fix Ghostty not opening to the selected directory

### DIFF
--- a/OpenInTerminalCore/Constants.swift
+++ b/OpenInTerminalCore/Constants.swift
@@ -28,6 +28,7 @@ struct Constants {
         static let kitty = "open -na kitty --args --single-instance --instance-group 1 --directory"
         static let wezterm = "open -na wezterm --args start --cwd"
         static let tabby = "open -na tabby --args --directory"
+        static let ghostty = "open -na Ghostty --args --working-directory"
         /// "Open In NeoVim" only supports Alacritty, wezterm, and kitty.
         static let neovim = "open -na kitty --args /opt/homebrew/bin/nvim PATH"
 //        static let neovim = "open -na wezterm --args start /opt/homebrew/bin/nvim PATH"

--- a/OpenInTerminalCore/DefaultsManager.swift
+++ b/OpenInTerminalCore/DefaultsManager.swift
@@ -270,6 +270,8 @@ public class DefaultsManager {
             return Constants.Commands.wezterm
         } else if SupportedApps.is(app, is: .tabby) {
             return Constants.Commands.tabby
+        } else if SupportedApps.is(app, is: .ghostty) {
+            return Constants.Commands.ghostty
         } else if SupportedApps.is(app, is: .neovim) {
             return neovimCommand
         } else {


### PR DESCRIPTION
## Summary

- Ghostty was falling through to the generic `open -a` handler, which passes the path as a file argument instead of a working directory
- Added a dedicated command constant `open -na Ghostty --args --working-directory` in `Constants.Commands`
- Added Ghostty case in `DefaultsManager.getOpenCommand()` to use the new command

This follows the same pattern used for Alacritty, kitty, WezTerm, and Tabby.

## Problem

When selecting Ghostty as the default terminal, OpenInTerminal opens Ghostty but does **not** `cd` into the selected Finder directory. Other terminals (WezTerm, Alacritty, kitty, Tabby) work correctly because they have dedicated launch commands with directory arguments.

## Test plan

- [ ] Set Ghostty as default terminal in OpenInTerminal
- [ ] Right-click a folder in Finder → Open in Terminal
- [ ] Verify Ghostty opens with the working directory set to the selected folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)