### PR TITLE
Add cmux and prevent app overwriting by default

### DIFF
--- a/OpenInTerminal/PreferencesWindow/Base.lproj/Preferences.storyboard
+++ b/OpenInTerminal/PreferencesWindow/Base.lproj/Preferences.storyboard
@@ -553,8 +553,18 @@
                                             <action selector="applyToContextButtonClicked:" target="s5W-qL-1Xs" id="hiv-kz-pHw"/>
                                         </connections>
                                     </button>
+                                    <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3er-uP-KiS">
+                                        <rect key="frame" x="18" y="47" width="235" height="18"/>
+                                        <buttonCell key="cell" type="check" title="Overwrite existing commands" bezelStyle="regularSquare" imagePosition="left" inset="2" id="o7G-Xu-dc8">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="overwriteExistingCommandsButtonClicked:" target="s5W-qL-1Xs" id="rYH-w2-9aN"/>
+                                        </connections>
+                                    </button>
                                     <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" ambiguous="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4us-6x-3pQ">
-                                        <rect key="frame" x="20" y="48" width="260" height="16"/>
+                                        <rect key="frame" x="20" y="24" width="260" height="16"/>
                                         <subviews>
                                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hH5-GT-YX7">
                                                 <rect key="frame" x="-2" y="0.0" width="67" height="16"/>
@@ -669,6 +679,7 @@
                                 <constraints>
                                     <constraint firstItem="4us-6x-3pQ" firstAttribute="leading" secondItem="pxi-dF-LO8" secondAttribute="leading" constant="20" id="CRm-C6-eJK"/>
                                     <constraint firstItem="5GI-nM-TKa" firstAttribute="leading" secondItem="pxi-dF-LO8" secondAttribute="leading" constant="20" id="Erw-fg-klC"/>
+                                    <constraint firstItem="3er-uP-KiS" firstAttribute="leading" secondItem="pxi-dF-LO8" secondAttribute="leading" constant="20" id="J8h-c1-VgJ"/>
                                     <constraint firstItem="teH-Uy-YOq" firstAttribute="leading" secondItem="pxi-dF-LO8" secondAttribute="leading" constant="20" id="hcZ-Kv-8Sj"/>
                                     <constraint firstAttribute="trailing" secondItem="5GI-nM-TKa" secondAttribute="trailing" constant="20" id="kNC-OB-Jgy"/>
                                     <constraint firstItem="jia-nD-S9J" firstAttribute="leading" secondItem="pxi-dF-LO8" secondAttribute="leading" constant="20" id="wim-XS-cz0"/>
@@ -683,8 +694,10 @@
                                     <integer value="1000"/>
                                     <integer value="1000"/>
                                     <integer value="1000"/>
+                                    <integer value="1000"/>
                                 </visibilityPriorities>
                                 <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
@@ -716,6 +729,7 @@
                         <outlet property="noIconButton" destination="B10-NC-B1J" id="2P9-Ma-BMt"/>
                         <outlet property="notInstalledApplicationsTextField" destination="e8s-z7-dmZ" id="g9m-4p-nHb"/>
                         <outlet property="originalIconButton" destination="qzh-XC-5Ni" id="dpl-2W-ZJn"/>
+                        <outlet property="overwriteExistingCommandsButton" destination="3er-uP-KiS" id="DZE-Ar-8F5"/>
                         <outlet property="pathNoButton" destination="M2J-AU-iO9" id="cCz-pG-pfn"/>
                         <outlet property="pathYesButton" destination="vhd-Cy-Io7" id="8se-Hp-u2x"/>
                         <outlet property="simpleIconButton" destination="Lag-Yy-a4i" id="HWS-9U-Hbk"/>

--- a/OpenInTerminal/PreferencesWindow/CustomPreferencesViewController.swift
+++ b/OpenInTerminal/PreferencesWindow/CustomPreferencesViewController.swift
@@ -25,6 +25,7 @@ class CustomPreferencesViewController: PreferencesViewController {
     var addOptionMenu: NSMenu = NSMenu()
     @IBOutlet weak var applyToToolbarButton: NSButton!
     @IBOutlet weak var applyToContextButton: NSButton!
+    @IBOutlet weak var overwriteExistingCommandsButton: NSButton!
     
     @IBOutlet weak var noIconButton: NSButton!
     @IBOutlet weak var simpleIconButton: NSButton!
@@ -141,6 +142,9 @@ class CustomPreferencesViewController: PreferencesViewController {
 
         let isApplyToContext = DefaultsManager.shared.isCustomMenuApplyToContext
         applyToContextButton.state = isApplyToContext ? .on : .off
+
+        let isOverwriteExistingCommands = DefaultsManager.shared.isCustomMenuOverwriteExistingCommands
+        overwriteExistingCommandsButton.state = isOverwriteExistingCommands ? .on : .off
         
         let isPathEscaped = DefaultsManager.shared.isPathEscaped
         if isPathEscaped {
@@ -329,6 +333,11 @@ class CustomPreferencesViewController: PreferencesViewController {
     @IBAction func applyToContextButtonClicked(_ sender: NSButton) {
         let isApplyTo = applyToContextButton.state == .on
         DefaultsManager.shared.isCustomMenuApplyToContext = isApplyTo
+    }
+
+    @IBAction func overwriteExistingCommandsButtonClicked(_ sender: NSButton) {
+        let isOverwriteExistingCommands = overwriteExistingCommandsButton.state == .on
+        DefaultsManager.shared.isCustomMenuOverwriteExistingCommands = isOverwriteExistingCommands
     }
     
     func showCustomInputViewController(_ appName: String = "") {

--- a/OpenInTerminal/PreferencesWindow/mul.lproj/Preferences.xcstrings
+++ b/OpenInTerminal/PreferencesWindow/mul.lproj/Preferences.xcstrings
@@ -2641,6 +2641,18 @@
         }
       }
     },
+    "o7G-Xu-dc8.title" : {
+      "comment" : "Class = \"NSButtonCell\"; title = \"Overwrite existing commands\"; ObjectID = \"o7G-Xu-dc8\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Overwrite existing commands"
+          }
+        }
+      }
+    },
     "OET-MK-jpV.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"No\"; ObjectID = \"OET-MK-jpV\";",
       "extractionState" : "extracted_with_value",

--- a/OpenInTerminalCore/Defaults.swift
+++ b/OpenInTerminalCore/Defaults.swift
@@ -49,6 +49,7 @@ public extension DefaultsKeys {
     static let customMenuOptions = DefaultsKey<Data>("CustomMenuOptions")
     static let customMenuApplyToToolbar = DefaultsKey<Bool>("CustomMenuApplyToToolbar")
     static let customMenuApplyToContext = DefaultsKey<Bool>("CustomMenuApplyToContext")
+    static let customMenuOverwriteExistingCommands = DefaultsKey<Bool>("CustomMenuOverwriteExistingCommands")
     static let customMenuIconOption = DefaultsKey<String>("CustomMenuIconOption")
     static let pathEscapeOption = DefaultsKey<Bool>("PathEscapeOption")
     static let kittyCommand = DefaultsKey<String>("KittyCommand")

--- a/OpenInTerminalCore/DefaultsManager.swift
+++ b/OpenInTerminalCore/DefaultsManager.swift
@@ -193,6 +193,16 @@ public class DefaultsManager {
             Defaults[.customMenuApplyToContext] = newValue
         }
     }
+
+    public var isCustomMenuOverwriteExistingCommands: Bool {
+        get {
+            return Defaults[.customMenuOverwriteExistingCommands]
+        }
+
+        set {
+            Defaults[.customMenuOverwriteExistingCommands] = newValue
+        }
+    }
     
     public var customMenuIconOption: CustomMenuIconOption {
         get {
@@ -294,6 +304,7 @@ public class DefaultsManager {
         setNewOption(.iTerm, .window)
         isCustomMenuApplyToToolbar = false
         isCustomMenuApplyToContext = false
+        isCustomMenuOverwriteExistingCommands = false
         customMenuIconOption = .no
         isPathEscaped = true
         Defaults.synchronize()

--- a/OpenInTerminalCore/SupportedApps.swift
+++ b/OpenInTerminalCore/SupportedApps.swift
@@ -19,6 +19,7 @@ public enum SupportedApps: String, CaseIterable {
     case wezterm = "WezTerm"
     case tabby = "Tabby"
     case warp = "Warp"
+    case cmux = "cmux"
     case githubDesktop = "GitHub Desktop"
     case fork = "Fork"
     case ghostty = "Ghostty"
@@ -70,7 +71,7 @@ public enum SupportedApps: String, CaseIterable {
     
     public var type: AppType {
         switch self {
-        case .terminal, .iTerm, .hyper, .alacritty, .kitty, .wezterm, .tabby, .warp, .githubDesktop, .fork, .ghostty:
+        case .terminal, .iTerm, .hyper, .alacritty, .kitty, .wezterm, .tabby, .warp, .cmux, .githubDesktop, .fork, .ghostty:
             return .terminal
         default:
             return .editor
@@ -113,6 +114,7 @@ public enum SupportedApps: String, CaseIterable {
         case .wezterm: return "com.github.wez.wezterm"
         case .tabby: return "org.tabby"
         case .warp: return "dev.warp"
+        case .cmux: return "com.cmuxterm.app"
         case .githubDesktop: return ""
         case .fork: return ""
         case .ghostty: return "com.mitchellh.ghostty"

--- a/OpenInTerminalFinderExtension/FinderSync.swift
+++ b/OpenInTerminalFinderExtension/FinderSync.swift
@@ -93,6 +93,7 @@ class FinderSync: FIFinderSync {
                                                                    comment: "Copy path to Clipboard"),
                                                 action: #selector(copyPathToClipboard),
                                                 keyEquivalent: "")
+            copyPathItem.target = self
             if DefaultsManager.shared.customMenuIconOption == .simple {
                 let copyPathIcon = NSImage(named: "context_menu_icon_path")
                 copyPathItem.image = copyPathIcon
@@ -103,28 +104,56 @@ class FinderSync: FIFinderSync {
             return copyPathItem
         }
     }
+
+    func addDefaultMenuItems(to menu: NSMenu) {
+        if let terminal = DefaultsManager.shared.defaultTerminal {
+            let terminalTitle = terminal.name
+            let openInTerminalItem = NSMenuItem(title: terminalTitle,
+                                                action: #selector(openDefaultTerminal),
+                                                keyEquivalent: "")
+            openInTerminalItem.target = self
+            let terminalIcon = DefaultsManager.shared.getAppIcon(terminal)
+            openInTerminalItem.image = terminalIcon
+            menu.addItem(openInTerminalItem)
+        }
+
+        if let editor = DefaultsManager.shared.defaultEditor {
+            let editorTitle = editor.name
+            let openInEditorItem = NSMenuItem(title: editorTitle,
+                                              action: #selector(openDefaultEditor),
+                                              keyEquivalent: "")
+            openInEditorItem.target = self
+            let editorIcon = DefaultsManager.shared.getAppIcon(editor)
+            openInEditorItem.image = editorIcon
+            menu.addItem(openInEditorItem)
+        }
+    }
+
+    @discardableResult
+    func addCustomMenuItems(to menu: NSMenu) -> Bool {
+        guard let customApps = DefaultsManager.shared.customMenuOptions,
+              !customApps.isEmpty else {
+            return false
+        }
+
+        customApps.forEach { app in
+            let itemTitle = app.name
+            let menuItem = NSMenuItem(title: itemTitle,
+                                      action: #selector(customMenuItemClicked),
+                                      keyEquivalent: "")
+            menuItem.target = self
+            let appIcon = DefaultsManager.shared.getAppIcon(app)
+            menuItem.image = appIcon
+            menu.addItem(menuItem)
+        }
+
+        return true
+    }
     
     func createDefaultMenu() -> NSMenu {
         let menu = NSMenu(title: "")
-        
-        guard let terminal = DefaultsManager.shared.defaultTerminal else { return menu }
-        let terminalTitle = terminal.name
-        let openInTerminalItem = NSMenuItem(title: terminalTitle,
-                                            action: #selector(openDefaultTerminal),
-                                            keyEquivalent: "")
-        let terminalIcon = DefaultsManager.shared.getAppIcon(terminal)
-        openInTerminalItem.image = terminalIcon
-        menu.addItem(openInTerminalItem)
-        
-        guard let editor = DefaultsManager.shared.defaultEditor else { return menu }
-        let editorTitle = editor.name
-        let openInEditorItem = NSMenuItem(title: editorTitle,
-                                            action: #selector(openDefaultEditor),
-                                            keyEquivalent: "")
-        let editorIcon = DefaultsManager.shared.getAppIcon(editor)
-        openInEditorItem.image = editorIcon
-        menu.addItem(openInEditorItem)
-        
+
+        addDefaultMenuItems(to: menu)
         // add "Copy Path"
         menu.addItem(self.copyPathItem)
         
@@ -133,21 +162,19 @@ class FinderSync: FIFinderSync {
     
     func createCustomMenu() -> NSMenu {
         let menu = NSMenu(title: "")
-        
-        // get saved custom apps
-        guard let customApps = DefaultsManager.shared.customMenuOptions else {
-            return menu
+
+        let isOverwriteExistingCommands = DefaultsManager.shared.isCustomMenuOverwriteExistingCommands
+        let defaultItemCount = menu.items.count
+        if !isOverwriteExistingCommands {
+            addDefaultMenuItems(to: menu)
         }
-        customApps.forEach { app in
-            let itemTitle = app.name
-            let menuItem = NSMenuItem(title: itemTitle,
-                                      action: #selector(customMenuItemClicked),
-                                      keyEquivalent: "")
-            let appIcon = DefaultsManager.shared.getAppIcon(app)
-            menuItem.image = appIcon
-            menu.addItem(menuItem)
+
+        let hasCustomItems = addCustomMenuItems(to: menu)
+
+        if menu.items.count > 0 {
+            menu.addItem(.separator())
         }
-        
+
         // add "Copy Path"
         menu.addItem(self.copyPathItem)
         

--- a/OpenInTerminalFinderExtension/FinderSync.swift
+++ b/OpenInTerminalFinderExtension/FinderSync.swift
@@ -171,10 +171,6 @@ class FinderSync: FIFinderSync {
 
         let hasCustomItems = addCustomMenuItems(to: menu)
 
-        if menu.items.count > 0 {
-            menu.addItem(.separator())
-        }
-
         // add "Copy Path"
         menu.addItem(self.copyPathItem)
         

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 | Features | OpenInTerminal | OpenInTerminal-Lite & OpenInEditor-Lite |
 | --- | --- | --- |
-| Support Terminal, [iTerm](https://www.iterm2.com/), [Hyper](https://github.com/zeit/hyper), [Alacritty](https://github.com/jwilm/alacritty), [kitty](https://sw.kovidgoyal.net/kitty/), [Warp](https://www.warp.dev), [WezTerm](https://wezfurlong.org/wezterm/index.html), [Tabby](https://tabby.sh), [Ghostty](https://ghostty.org/). | ✅ | ✅ |
+| Support Terminal, [iTerm](https://www.iterm2.com/), [Hyper](https://github.com/zeit/hyper), [Alacritty](https://github.com/jwilm/alacritty), [kitty](https://sw.kovidgoyal.net/kitty/), [Warp](https://www.warp.dev), [WezTerm](https://wezfurlong.org/wezterm/index.html), [Tabby](https://tabby.sh), [Ghostty](https://ghostty.org/), [cmux](https://github.com/manaflow-ai/cmux). | ✅ | ✅ |
 | Support TextEdit, Xcode, [Visual Studio Code](https://code.visualstudio.com/), [VSCode Insiders](https://code.visualstudio.com/insiders/), [Atom](https://atom.io/), [Sublime Text](https://www.sublimetext.com/), [VSCodium](https://github.com/VSCodium/vscodium), [BBEdit](https://www.barebones.com/products/bbedit/), [TextMate](https://macromates.com), [CotEditor](https://coteditor.com/), [MacVim](https://github.com/macvim-dev/macvim), [JetBrains](https://www.jetbrains.com/)(AppCode, CLion, GoLand, IntelliJ IDEA, PhpStorm, PyCharm, RubyMine, WebStorm, Android Studio, Fleet), [Typora](https://typora.io/), [Nova](https://nova.app/), [Cursor](https://cursor.sh/), [notepad--](https://github.com/cxasm/notepad--), [neovim](https://neovim.io/). | ✅ | ✅ |
 | Open in custom apps. (⚠️ Not all apps support.) | ✅ | ✅ |
 | Support English, Chinese, French, Russian, Italian, Spanish, Turkish, German and Korean | ✅ | ✅ |

--- a/Resources/README-Lite-zh.md
+++ b/Resources/README-Lite-zh.md
@@ -83,6 +83,7 @@ defaults remove wang.jianing.app.OpenInEditor-Lite LiteDefaultEditor
 | 应用 | 命令 |
 | --- | --- |
 | Alacritty | `defaults write wang.jianing.app.OpenInTerminal-Lite LiteDefaultTerminal Alacritty` |
+| cmux | `defaults write wang.jianing.app.OpenInTerminal-Lite LiteDefaultTerminal cmux` |
 | kitty | `defaults write wang.jianing.app.OpenInTerminal-Lite LiteDefaultTerminal kitty` |
 | TextEdit | `defaults write wang.jianing.app.OpenInEditor-Lite LiteDefaultEditor TextEdit` |
 | VSCodium | `defaults write wang.jianing.app.OpenInEditor-Lite LiteDefaultEditor VSCodium` |

--- a/Resources/README-Lite.md
+++ b/Resources/README-Lite.md
@@ -87,6 +87,7 @@ Set the following app as the default app to open:
 | App | Command |
 | --- | --- |
 | Alacritty | `defaults write wang.jianing.app.OpenInTerminal-Lite LiteDefaultTerminal Alacritty` |
+| cmux | `defaults write wang.jianing.app.OpenInTerminal-Lite LiteDefaultTerminal cmux` |
 | kitty | `defaults write wang.jianing.app.OpenInTerminal-Lite LiteDefaultTerminal kitty` |
 | TextEdit | `defaults write wang.jianing.app.OpenInEditor-Lite LiteDefaultEditor TextEdit` |
 | VSCodium | `defaults write wang.jianing.app.OpenInEditor-Lite LiteDefaultEditor VSCodium` |

--- a/Resources/README-zh.md
+++ b/Resources/README-zh.md
@@ -14,7 +14,7 @@
 
 | 功能 | OpenInTerminal | OpenInTerminal-Lite & OpenInEditor-Lite |
 | --- | --- | --- |
-| 支持 终端, [iTerm](https://www.iterm2.com/), [Hyper](https://github.com/zeit/hyper), [Alacritty](https://github.com/jwilm/alacritty), [kitty](https://sw.kovidgoyal.net/kitty/), [Warp](https://www.warp.dev), [WezTerm](https://wezfurlong.org/wezterm/index.html), [Tabby](https://tabby.sh), [Ghostty](https://ghostty). | ✅ | ✅ |
+| 支持 终端, [iTerm](https://www.iterm2.com/), [Hyper](https://github.com/zeit/hyper), [Alacritty](https://github.com/jwilm/alacritty), [kitty](https://sw.kovidgoyal.net/kitty/), [Warp](https://www.warp.dev), [WezTerm](https://wezfurlong.org/wezterm/index.html), [Tabby](https://tabby.sh), [Ghostty](https://ghostty.org/), [cmux](https://github.com/manaflow-ai/cmux). | ✅ | ✅ |
 | 支持 文本编辑, Xcode, [Visual Studio Code](https://code.visualstudio.com/), [VSCode Insiders](https://code.visualstudio.com/insiders/), [Atom](https://atom.io/), [Sublime Text](https://www.sublimetext.com/), [VSCodium](https://github.com/VSCodium/vscodium), [BBEdit](https://www.barebones.com/products/bbedit/), [TextMate](https://macromates.com), [CotEditor](https://coteditor.com/), [MacVim](https://github.com/macvim-dev/macvim), [JetBrains](https://www.jetbrains.com/)(AppCode, CLion, GoLand, IntelliJ IDEA, PhpStorm, PyCharm, RubyMine, WebStorm, Android Studio, Fleet), [Typora](https://typora.io/), [Nova](https://nova.app/), [Cursor](https://cursor.sh/), [notepad--](https://github.com/cxasm/notepad--), [neovim](https://neovim.io/). | ✅ | ✅ |
 | 打开自定义应用（⚠️ 并不是所有的应用都支持） | ✅ | ✅ |
 | 支持中文，英语，法语，俄语，意大利语，西班牙语，土耳其语, 德语, 韩语 | ✅ | ✅ |


### PR DESCRIPTION
## Summary of this pull request
This PR does 2 things, it adds support for the cmux terminal app and adds an option to disable overwriting other commands when you add a custom one.
## Does this solve an existing issue? If so, add a link to it
No
## Steps to test this feature

## Screenshots

See cmux as a new terminal option:
<img width="438" height="440" alt="Screenshot 2026-03-29 at 9 52 32 AM" src="https://github.com/user-attachments/assets/ea7cfe0d-fed2-4c91-ad00-d52c6a5db70f" />

When I added cmux as a custom option, it wouldn't knock out VSCode and iTerm from the context/finder menus with the new option:
<img width="242" height="325" alt="Screenshot 2026-03-29 at 9 56 46 AM" src="https://github.com/user-attachments/assets/d2c774d3-3aca-4124-8c44-6c89e6314fde" />



<img width="427" height="606" alt="Screenshot 2026-03-29 at 9 57 03 AM" src="https://github.com/user-attachments/assets/ffbd889c-8634-415e-afeb-5efc1323b1c3" />

If I enable the new option, the previous behavior is enabled (where it overwrites the default terminal and editor)
<img width="244" height="265" alt="Screenshot 2026-03-29 at 9 58 07 AM" src="https://github.com/user-attachments/assets/09d22ad7-bb7a-47d5-9f8f-90317d94dc24" />

## Additional info

