### PR TITLE
perf: cache installed app scans

### DIFF
--- a/OpenInTerminal/PreferencesWindow/CustomPreferencesViewController.swift
+++ b/OpenInTerminal/PreferencesWindow/CustomPreferencesViewController.swift
@@ -35,13 +35,7 @@ class CustomPreferencesViewController: PreferencesViewController {
     
     private var dragDropType = NSPasteboard.PasteboardType(rawValue: "private.table-row")
     
-    var allInstalledAppNames: Set<String> = Set() {
-        didSet {
-            DispatchQueue.main.async {
-                self.refreshSupportedApps()
-            }
-        }
-    }
+    var allInstalledAppNames: Set<String> = Set()
     var installedSupportedAppNames: [String] = []
         
     var customMenuOptions = [App]() {
@@ -65,10 +59,16 @@ class CustomPreferencesViewController: PreferencesViewController {
     
     override func viewWillAppear() {
         super.viewWillAppear()
-        // fetch installed apps
-        DispatchQueue.global(qos: .background).async {
-            self.allInstalledAppNames = FinderManager.shared.getAllInstalledApps()
+
+        if let applications = FinderManager.shared.getCachedInstalledApps() {
+            allInstalledAppNames = applications
         }
+        FinderManager.shared.refreshInstalledApps { [weak self] applications in
+            guard let self = self, self.allInstalledAppNames != applications else { return }
+            self.allInstalledAppNames = applications
+            self.refreshSupportedApps()
+        }
+
         // get saved custom menu apps
         if let customMenuOptions = DefaultsManager.shared.customMenuOptions {
             self.customMenuOptions = customMenuOptions

--- a/OpenInTerminal/PreferencesWindow/GeneralPreferencesViewController.swift
+++ b/OpenInTerminal/PreferencesWindow/GeneralPreferencesViewController.swift
@@ -57,10 +57,22 @@ class GeneralPreferencesViewController: PreferencesViewController {
     
     override func viewWillAppear() {
         super.viewWillAppear()
-        allInstalledApps = FinderManager.shared.getAllInstalledApps()
         refreshButtonState()
-        refreshDefaultTerminal()
-        refreshDefaultEditor()
+
+        if let applications = FinderManager.shared.getCachedInstalledApps() {
+            updateInstalledApps(applications)
+        } else {
+            showCurrentDefaultsWhileLoading()
+        }
+
+        FinderManager.shared.refreshInstalledApps { [weak self] applications in
+            guard let self = self else { return }
+            if self.allInstalledApps != applications || self.installedTerminals == nil {
+                self.updateInstalledApps(applications)
+            }
+            self.defaultTerminalButton.isEnabled = true
+            self.defaultEditorButton.isEnabled = true
+        }
     }
     
     override func viewDidAppear() {
@@ -79,6 +91,31 @@ class GeneralPreferencesViewController: PreferencesViewController {
     }
     
     // MARK: Refresh UI
+
+    func showCurrentDefaultsWhileLoading() {
+        defaultTerminalButton.removeAllItems()
+        defaultEditorButton.removeAllItems()
+
+        if let terminal = DefaultsManager.shared.defaultTerminal {
+            defaultTerminalButton.addItem(withTitle: terminal.name)
+        }
+        if let editor = DefaultsManager.shared.defaultEditor {
+            defaultEditorButton.addItem(withTitle: editor.name)
+        }
+
+        installedTerminals = nil
+        installedEditors = nil
+        defaultTerminalButton.isEnabled = false
+        defaultEditorButton.isEnabled = false
+    }
+
+    func updateInstalledApps(_ applications: Set<String>) {
+        allInstalledApps = applications
+        refreshDefaultTerminal()
+        refreshDefaultEditor()
+        defaultTerminalButton.isEnabled = true
+        defaultEditorButton.isEnabled = true
+    }
     
     func refreshButtonState() {
         let isLaunchAtLogin = DefaultsManager.shared.isLaunchAtLogin

--- a/OpenInTerminalCore/FinderManager.swift
+++ b/OpenInTerminalCore/FinderManager.swift
@@ -12,6 +12,14 @@ import ScriptingBridge
 public class FinderManager {
     
     public static var shared = FinderManager()
+
+    private let installedAppsQueue = DispatchQueue(label: "wang.jianing.app.OpenInTerminal.installed-apps",
+                                                    qos: .utility)
+    private let installedAppsScanQueue = DispatchQueue(label: "wang.jianing.app.OpenInTerminal.installed-apps-scan",
+                                                        qos: .utility)
+    private var installedAppsCache: Set<String>?
+    private var installedAppsCallbacks = [(Set<String>) -> Void]()
+    private var isRefreshingInstalledApps = false
     
     /// Get full url to front Finder window or selected file
     public func getFullUrlToFrontFinderWindowOrSelectedFile() throws -> URL? {
@@ -130,8 +138,47 @@ public class FinderManager {
         return desktopPath
     }
     
-    /// Get all installed applications' names
+    /// Get the most recently scanned installed applications, if available.
+    public func getCachedInstalledApps() -> Set<String>? {
+        return installedAppsQueue.sync {
+            installedAppsCache
+        }
+    }
+
+    /// Refresh installed applications off the main thread.
+    /// Concurrent callers share the same scan. Completions run on the main thread.
+    public func refreshInstalledApps(completion: @escaping (Set<String>) -> Void) {
+        installedAppsQueue.async {
+            self.installedAppsCallbacks.append(completion)
+            guard !self.isRefreshingInstalledApps else { return }
+
+            self.isRefreshingInstalledApps = true
+            self.installedAppsScanQueue.async {
+                let applications = self.scanInstalledApps()
+                self.installedAppsQueue.async {
+                    self.installedAppsCache = applications
+                    self.isRefreshingInstalledApps = false
+
+                    let callbacks = self.installedAppsCallbacks
+                    self.installedAppsCallbacks.removeAll()
+                    DispatchQueue.main.async {
+                        callbacks.forEach { $0(applications) }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get all installed applications' names synchronously.
     public func getAllInstalledApps() -> Set<String> {
+        let applications = scanInstalledApps()
+        installedAppsQueue.sync {
+            installedAppsCache = applications
+        }
+        return applications
+    }
+
+    private func scanInstalledApps() -> Set<String> {
         var applications: Set<String> = Set()
         // add system application
         applications.insert("Terminal")


### PR DESCRIPTION
## What changed

- cache installed application scan results for the current app session
- coalesce concurrent refresh requests onto one background scan
- show cached defaults immediately in General preferences
- share the same refresh path with Custom preferences

## Why

Opening General preferences synchronously scanned `/Applications`, the user
Applications directory, and JetBrains Toolbox on the main thread. Machines
with many applications or deep Toolbox directories could block the settings
window while the default terminal and editor lists were populated.

## Impact

The settings window now appears immediately. Cached application lists are
shown when available, then refreshed in the background without changing the
stored default terminal or editor format.

## Validation

- `git diff --check`
- Swift frontend syntax parsing for the changed files
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./build-unsigned.sh`
  - OpenInTerminal.app
  - OpenInTerminal-Lite.app
  - OpenInEditor-Lite.app
